### PR TITLE
docs: fix package being installed as devDependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ In order to have the all currency and locale patterns in one place.
 The data is generated from [CLDR33](http://unicode.org/Public/cldr/33/core.zip).
 
 ## Installation
+### npm
+`npm install --save krokus`
 
-`npm install --save-dev krokus`
+### yarn
+`yarn add krokus`
 
 -----
 


### PR DESCRIPTION
If I'm not mistaken it probably makes sense to install this library as production dependency and not only as devDependency.

Please let me know if I got it wrong. :)